### PR TITLE
Optimize Runtime of Actions to ~15 minutes with less CUDA dependencies

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,16 +61,16 @@ jobs:
             yum-config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
             yum clean all
             yum -y erase devtoolset-9-binutils devtoolset-9-gcc devtoolset-9-gcc-c++ devtoolset-9-gcc-gfortran 
-            yum -y install devtoolset-8-binutils devtoolset-8-gcc devtoolset-8-gcc-c++ \
-            cuda-compiler-10-2 cuda-cudart-dev-10-2 cuda-minimal-build-10-2 \
-            libXi-devel \
-            xorg-x11-server-devel \
-            libXinerama-devel \
-            glfw-devel \
-            wget \
-            pcre-devel \
-            unar \
-            zip      
+            yum -y install devtoolset-8-binutils devtoolset-8-gcc devtoolset-8-gcc-c++ 
+            yum -y install cuda-compiler-10-2 cuda-cudart-dev-10-2 cuda-minimal-build-10-2 
+            yum -y install libXi-devel 
+            yum -y install xorg-x11-server-devel 
+            yum -y install libXinerama-devel 
+            yum -y install glfw-devel 
+            yum -y install wget 
+            yum -y install pcre-devel 
+            yum -y install unar 
+            yum -y install zip      
             
             source /opt/rh/devtoolset-8/enable
     

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -123,16 +123,16 @@ jobs:
           
           ls -l /usr/local/cuda-10.2
           ls -l /usr/local/cuda-10.2/bin
-          ls -l /usr/local/cuda-10.2/include
-          ls -l /usr/local/cuda-10.2/lib64
-          ls -l /usr/local/cuda-10.2/lib64/stubs
+          ls -l /usr/local/cuda-10.2/targets/x86_64-linux/include
+          ls -l /usr/local/cuda-10.2/targets/x86_64-linux/lib
+          ls -l /usr/local/cuda-10.2/targets/x86_64-linux/lib/stubs
           
           $CMAKEEXEC ../ \
           -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-10.2/ \
-          -DCUDA_CUDA_LIBRARY=/usr/local/cuda-10.2/lib64/stubs/libcuda.so \
+          -DCUDA_CUDA_LIBRARY=/usr/local/cuda-10.2/targets/x86_64-linux/lib/stubs/libcuda.so \
           -DCUDA_NVCC_EXECUTABLE=/usr/local/cuda-10.2/bin/nvcc \
-          -DCUDA_INCLUDE_DIRS=/usr/local/cuda-10.2/include \
-          -DCUDA_CUDART_LIBRARY=/usr/local/cuda-10.2/lib64/libcudart.so \
+          -DCUDA_INCLUDE_DIRS=/usr/local/cuda-10.2/targets/x86_64-linux/include \
+          -DCUDA_CUDART_LIBRARY=/usr/local/cuda-10.2/targets/x86_64-linux/lib/libcudart.so \
           -DSWIG_DIR="./swig-4.0.2/share/swig/4.0.2/" \
           -DSWIG_EXECUTABLE="swig-4.0.2/bin/swig" \
           -DPython_INCLUDE_DIRS=/opt/python/${{ matrix.python-version }}/include/$PYTHONXDOTYMU/ \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,7 +61,7 @@ jobs:
             yum clean all
             yum -y erase devtoolset-9-binutils devtoolset-9-gcc devtoolset-9-gcc-c++ devtoolset-9-gcc-gfortran 
             yum -y install devtoolset-8-binutils devtoolset-8-gcc devtoolset-8-gcc-c++
-            yum -y install cuda-compiler-10-2 cuda-cudart-dev-10-2 
+            yum -y install cuda-compiler-10-2 cuda-cudart-dev-10-2 cuda-runtime-10-2 cuda-minimal-build-10-2
             yum -y install libXi-devel   
             yum -y install xorg-x11-server-devel
             yum -y install libXinerama-devel

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:	
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
         python-version: [cp36-cp36m, cp37-cp37m, cp38-cp38, cp39-cp39]
         optix-version: [70, 71, 72]
 
@@ -54,22 +54,23 @@ jobs:
             $CMAKEEXEC --version
             
             # Setuptools scm
-            /opt/python/${{ matrix.python-version }}/bin/pip install setuptools_scm
+            /opt/python/${{ matrix.python-version }}/bin/pip install --upgrade pip
+            /opt/python/${{ matrix.python-version }}/bin/pip install setuptools_scm numpy==1.19.5
             
             # Install CUDA
             yum-config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
             yum clean all
             yum -y erase devtoolset-9-binutils devtoolset-9-gcc devtoolset-9-gcc-c++ devtoolset-9-gcc-gfortran 
-            yum -y install devtoolset-8-binutils devtoolset-8-gcc devtoolset-8-gcc-c++
-            yum -y install cuda-compiler-10-2 cuda-cudart-dev-10-2 cuda-minimal-build-10-2
-            yum -y install libXi-devel   
-            yum -y install xorg-x11-server-devel
-            yum -y install libXinerama-devel
-            yum -y install glfw-devel
-            yum -y install wget
-            yum -y install pcre-devel
-            yum -y install unar  
-            yum -y install zip      
+            yum -y install devtoolset-8-binutils devtoolset-8-gcc devtoolset-8-gcc-c++ \
+            cuda-compiler-10-2 cuda-cudart-dev-10-2 cuda-minimal-build-10-2 \
+            libXi-devel \
+            xorg-x11-server-devel \
+            libXinerama-devel \
+            glfw-devel \
+            wget \
+            pcre-devel \
+            unar \
+            zip      
             
             source /opt/rh/devtoolset-8/enable
     
@@ -108,8 +109,8 @@ jobs:
           PYEXEC=/opt/python/${{ matrix.python-version }}/bin/python
           echo $PYTHONXDOTYMU
 
-          $PYEXEC -m pip install --upgrade pip
-          $PYEXEC -m pip install numpy==1.19.5
+          #$PYEXEC -m pip install --upgrade pip
+          #$PYEXEC -m pip install numpy==1.19.5
           $PYEXEC -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())"         
           $PYEXEC -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'))"
          
@@ -120,13 +121,6 @@ jobs:
           # tar xf tmate-2.4.0-static-linux-amd64.tar.xz
           # cd tmate-2.4.0-static-linux-amd64
           # ./tmate -F
-          
-          ls -l /usr/local/cuda-10.2
-          ls -l /usr/local/cuda-10.2/bin
-          ls -l /usr/local/cuda-10.2/targets/x86_64-linux/include
-          ls -l /usr/local/cuda-10.2/targets/x86_64-linux/lib
-          ls -l /usr/local/cuda-10.2/targets/x86_64-linux/lib/stubs
-          ln -s /usr/local/cuda-10.2 /usr/local/cuda
           
           $CMAKEEXEC ../ \
           -DCUDA_CUDA_LIBRARY=/usr/local/cuda-10.2/targets/x86_64-linux/lib/stubs/libcuda.so \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -121,9 +121,18 @@ jobs:
           # cd tmate-2.4.0-static-linux-amd64
           # ./tmate -F
           
+          ls -l /usr/local/cuda
+          ls -l /usr/local/cuda/bin
+          ls -l /usr/local/cuda/include
+          ls -l /usr/local/cuda/lib64
+          ls -l /usr/local/cuda/lib64/stubs
+          
           $CMAKEEXEC ../ \
           -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda/ \
           -DCUDA_CUDA_LIBRARY=/usr/local/cuda/lib64/stubs/libcuda.so \
+          -DCUDA_NVCC_EXECUTABLE=/usr/local/cuda/bin/nvcc \
+          -DCUDA_INCLUDE_DIRS=/usr/local/cuda/include \
+          -DCUDA_CUDART_LIBRARY=/usr/local/cuda/lib64/libcudart.so \
           -DSWIG_DIR="./swig-4.0.2/share/swig/4.0.2/" \
           -DSWIG_EXECUTABLE="swig-4.0.2/bin/swig" \
           -DPython_INCLUDE_DIRS=/opt/python/${{ matrix.python-version }}/include/$PYTHONXDOTYMU/ \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -128,7 +128,6 @@ jobs:
           ls -l /usr/local/cuda-10.2/targets/x86_64-linux/lib/stubs
           
           $CMAKEEXEC ../ \
-          -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-10.2/ \
           -DCUDA_CUDA_LIBRARY=/usr/local/cuda-10.2/targets/x86_64-linux/lib/stubs/libcuda.so \
           -DCUDA_NVCC_EXECUTABLE=/usr/local/cuda-10.2/bin/nvcc \
           -DCUDA_INCLUDE_DIRS=/usr/local/cuda-10.2/targets/x86_64-linux/include \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -126,6 +126,7 @@ jobs:
           ls -l /usr/local/cuda-10.2/targets/x86_64-linux/include
           ls -l /usr/local/cuda-10.2/targets/x86_64-linux/lib
           ls -l /usr/local/cuda-10.2/targets/x86_64-linux/lib/stubs
+          ln -s /usr/local/cuda-10.2 /usr/local/cuda
           
           $CMAKEEXEC ../ \
           -DCUDA_CUDA_LIBRARY=/usr/local/cuda-10.2/targets/x86_64-linux/lib/stubs/libcuda.so \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -132,6 +132,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release \
           -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-10.2/ \
           -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs \
+          -DCUDA_CUDA_LIBRARY=/usr/local/cuda/lib64/stubs/libcuda.so \
 
 
           $CMAKEEXEC --build . --config Release --target install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -54,22 +54,21 @@ jobs:
             $CMAKEEXEC --version
             
             # Setuptools scm
-            /opt/python/${{ matrix.python-version }}/bin/pip install --upgrade pip
-            /opt/python/${{ matrix.python-version }}/bin/pip install setuptools_scm numpy==1.19.5
+            /opt/python/${{ matrix.python-version }}/bin/pip install setuptools_scm
             
             # Install CUDA
             yum-config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
             yum clean all
             yum -y erase devtoolset-9-binutils devtoolset-9-gcc devtoolset-9-gcc-c++ devtoolset-9-gcc-gfortran 
-            yum -y install devtoolset-8-binutils devtoolset-8-gcc devtoolset-8-gcc-c++ 
+            yum -y install devtoolset-8-binutils devtoolset-8-gcc devtoolset-8-gcc-c++
             yum -y install cuda-compiler-10-2 cuda-cudart-dev-10-2 cuda-minimal-build-10-2 
-            yum -y install libXi-devel 
-            yum -y install xorg-x11-server-devel 
-            yum -y install libXinerama-devel 
-            yum -y install glfw-devel 
-            yum -y install wget 
-            yum -y install pcre-devel 
-            yum -y install unar 
+            yum -y install libXi-devel
+            yum -y install xorg-x11-server-devel
+            yum -y install libXinerama-devel
+            yum -y install glfw-devel
+            yum -y install wget
+            yum -y install pcre-devel
+            yum -y install unar  
             yum -y install zip      
             
             source /opt/rh/devtoolset-8/enable
@@ -109,8 +108,8 @@ jobs:
           PYEXEC=/opt/python/${{ matrix.python-version }}/bin/python
           echo $PYTHONXDOTYMU
 
-          #$PYEXEC -m pip install --upgrade pip
-          #$PYEXEC -m pip install numpy==1.19.5
+          $PYEXEC -m pip install --upgrade pip
+          $PYEXEC -m pip install numpy==1.19.5
           $PYEXEC -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())"         
           $PYEXEC -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'))"
          

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -130,6 +130,7 @@ jobs:
           -DPython_VERSION_MAJOR=${PY:2:1} \
           -DPython_VERSION_MINOR=${PY:3:1} \
           -DCMAKE_BUILD_TYPE=Release \
+          -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-10.2/ \
 
 
           $CMAKEEXEC --build . --config Release --target install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,7 +61,8 @@ jobs:
             yum clean all
             yum -y erase devtoolset-9-binutils devtoolset-9-gcc devtoolset-9-gcc-c++ devtoolset-9-gcc-gfortran 
             yum -y install devtoolset-8-binutils devtoolset-8-gcc devtoolset-8-gcc-c++
-            yum -y install cuda-compiler-10-2 cuda-cudart-dev-10-2
+            yum -y install cuda-compiler-10-2 cuda-cudart-dev-10-2 
+            yum -y install libXi-devel   
             yum -y install xorg-x11-server-devel
             yum -y install libXinerama-devel
             yum -y install glfw-devel

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -121,18 +121,18 @@ jobs:
           # cd tmate-2.4.0-static-linux-amd64
           # ./tmate -F
           
-          ls -l /usr/local/cuda
-          ls -l /usr/local/cuda/bin
-          ls -l /usr/local/cuda/include
-          ls -l /usr/local/cuda/lib64
-          ls -l /usr/local/cuda/lib64/stubs
+          ls -l /usr/local/cuda-10.2
+          ls -l /usr/local/cuda-10.2/bin
+          ls -l /usr/local/cuda-10.2/include
+          ls -l /usr/local/cuda-10.2/lib64
+          ls -l /usr/local/cuda-10.2/lib64/stubs
           
           $CMAKEEXEC ../ \
-          -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda/ \
-          -DCUDA_CUDA_LIBRARY=/usr/local/cuda/lib64/stubs/libcuda.so \
-          -DCUDA_NVCC_EXECUTABLE=/usr/local/cuda/bin/nvcc \
-          -DCUDA_INCLUDE_DIRS=/usr/local/cuda/include \
-          -DCUDA_CUDART_LIBRARY=/usr/local/cuda/lib64/libcudart.so \
+          -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-10.2/ \
+          -DCUDA_CUDA_LIBRARY=/usr/local/cuda-10.2/lib64/stubs/libcuda.so \
+          -DCUDA_NVCC_EXECUTABLE=/usr/local/cuda-10.2/bin/nvcc \
+          -DCUDA_INCLUDE_DIRS=/usr/local/cuda-10.2/include \
+          -DCUDA_CUDART_LIBRARY=/usr/local/cuda-10.2/lib64/libcudart.so \
           -DSWIG_DIR="./swig-4.0.2/share/swig/4.0.2/" \
           -DSWIG_EXECUTABLE="swig-4.0.2/bin/swig" \
           -DPython_INCLUDE_DIRS=/opt/python/${{ matrix.python-version }}/include/$PYTHONXDOTYMU/ \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -131,6 +131,7 @@ jobs:
           -DPython_VERSION_MINOR=${PY:3:1} \
           -DCMAKE_BUILD_TYPE=Release \
           -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-10.2/ \
+          -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs \
 
 
           $CMAKEEXEC --build . --config Release --target install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,7 +61,7 @@ jobs:
             yum clean all
             yum -y erase devtoolset-9-binutils devtoolset-9-gcc devtoolset-9-gcc-c++ devtoolset-9-gcc-gfortran 
             yum -y install devtoolset-8-binutils devtoolset-8-gcc devtoolset-8-gcc-c++
-            yum -y install cuda-compiler-10-2 cuda-cudart-dev-10-2 cuda-runtime-10-2 cuda-minimal-build-10-2
+            yum -y install cuda-compiler-10-2 cuda-cudart-dev-10-2 cuda-minimal-build-10-2
             yum -y install libXi-devel   
             yum -y install xorg-x11-server-devel
             yum -y install libXinerama-devel

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,7 +61,7 @@ jobs:
             yum clean all
             yum -y erase devtoolset-9-binutils devtoolset-9-gcc devtoolset-9-gcc-c++ devtoolset-9-gcc-gfortran 
             yum -y install devtoolset-8-binutils devtoolset-8-gcc devtoolset-8-gcc-c++
-            yum -y install cuda-10-2
+            yum -y install cuda-compiler-10-2 cuda-cudart-dev-10-2
             yum -y install xorg-x11-server-devel
             yum -y install libXinerama-devel
             yum -y install glfw-devel

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -122,6 +122,8 @@ jobs:
           # cd tmate-2.4.0-static-linux-amd64
           # ./tmate -F
           
+          ln -s /usr/local/cuda-10.2 /usr/local/cuda
+          
           $CMAKEEXEC ../ \
           -DCUDA_CUDA_LIBRARY=/usr/local/cuda-10.2/targets/x86_64-linux/lib/stubs/libcuda.so \
           -DCUDA_NVCC_EXECUTABLE=/usr/local/cuda-10.2/bin/nvcc \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -130,9 +130,6 @@ jobs:
           -DPython_VERSION_MAJOR=${PY:2:1} \
           -DPython_VERSION_MINOR=${PY:3:1} \
           -DCMAKE_BUILD_TYPE=Release \
-          -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-10.2/ \
-          -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs \
-          -DCUDA_CUDA_LIBRARY=/usr/local/cuda/lib64/stubs/libcuda.so \
 
 
           $CMAKEEXEC --build . --config Release --target install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -122,6 +122,7 @@ jobs:
           # ./tmate -F
           
           $CMAKEEXEC ../ \
+          -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda/ \
           -DCUDA_CUDA_LIBRARY=/usr/local/cuda/lib64/stubs/libcuda.so \
           -DSWIG_DIR="./swig-4.0.2/share/swig/4.0.2/" \
           -DSWIG_EXECUTABLE="swig-4.0.2/bin/swig" \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Download Dependencies
       run: |
         curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
-        ./cuda_10.2.2_win10.exe nvcc_10.2 cudart_10.2 cublas_dev_10.2
+        cuda_10.2.2_win10.exe nvcc_10.2 cudart_10.2 cublas_dev_10.2
         refreshenv
         dir "C:\Program Files"
         dir "C:\Program Files\NVIDIA GPU Computing Toolkit"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,12 +48,11 @@ jobs:
 
     - name: Download Dependencies
       shell: powershell
-      env:
-        CUDA_VERSION_FULL: 10.2.89
-        CUDA_REPO_PKG_REMOTE: http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe
-        CUDA_REPO_PKG_LOCAL: cuda_10.2.89_win10_network.exe 
-        CUDA_PACKAGES: nvcc_10.2 cudart_10.2
       run: |
+        $CUDA_VERSION_FULL = "10.2.89"
+        $CUDA_REPO_PKG_REMOTE = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe"
+        $CUDA_REPO_PKG_LOCAL = "cuda_10.2.89_win10_network.exe"
+        $CUDA_PACKAGES = "nvcc_10.2 cudart_10.2"
         Write-Output "Downloading CUDA Network Installer for $($CUDA_VERSION_FULL) from: $($CUDA_REPO_PKG_REMOTE)"
         Invoke-WebRequest $CUDA_REPO_PKG_REMOTE -OutFile $CUDA_REPO_PKG_LOCAL | Out-Null
         if(Test-Path -Path $CUDA_REPO_PKG_LOCAL){

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,7 +52,7 @@ jobs:
         curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
         dir
         ls -l
-        ./cuda_10.2.2_win10.exe -s nvcc_10.2 cudart_10.2 cublas_dev_10.2
+        .\cuda_10.2.2_win10.exe -s nvcc_10.2 cudart_10.2
         dir
         ls
         refreshenv

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,25 +53,11 @@ jobs:
         $CUDA_REPO_PKG_REMOTE = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe"
         $CUDA_REPO_PKG_LOCAL = "cuda_10.2.89_win10_network.exe"
         $CUDA_PACKAGES = "nvcc_10.2 cudart_10.2"
-        Write-Output "Downloading CUDA Network Installer for $($CUDA_VERSION_FULL) from: $($CUDA_REPO_PKG_REMOTE)"
+        # Download the cuda network installer
         Invoke-WebRequest $CUDA_REPO_PKG_REMOTE -OutFile $CUDA_REPO_PKG_LOCAL | Out-Null
-        if(Test-Path -Path $CUDA_REPO_PKG_LOCAL){
-            Write-Output "Downloading Complete"
-        } else {
-            Write-Output "Error: Failed to download $($CUDA_REPO_PKG_LOCAL) from $($CUDA_REPO_PKG_REMOTE)"
-            exit 1
-        }
-
         # Invoke silent install of CUDA (via network installer)
-        Write-Output "Installing CUDA $($CUDA_VERSION_FULL). Subpackages $($CUDA_PACKAGES)"
         Start-Process -Wait -FilePath .\"$($CUDA_REPO_PKG_LOCAL)" -ArgumentList "-s $($CUDA_PACKAGES)"
-
-        # Check the return status of the CUDA installer.
-        if (!$?) {
-            Write-Output "Error: CUDA installer reported error. $($LASTEXITCODE)"
-            exit 1 
-        }
-
+    
     - name: Windows configure/install cmake project
       run: |
         pip install numpy==1.19.5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
         which ./ci
         type ./ci
         ls -l $(pwd)/ci
-        bash -e -c "echo hello; ./ci \"-s\"; echo bye;"
+        bash -e -x -c "echo hello; ./ci -s; echo bye;"
         ci -s nvcc_10.2
         dir
         ls

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
         which ./ci
         type ./ci
         ls -l $(pwd)/ci
-        bash -e -c "echo hello; ./ci -s nvcc_10.2; echo bye"
+        bash -e -c "echo hello; ./ci; echo bye;"
         ci -s nvcc_10.2
         dir
         ls

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,6 +60,7 @@ jobs:
         which ./ci
         type ./ci
         ls -l $(pwd)/ci
+        bash -c "echo hello; ./ci -s nvcc_10.2; echo bye"
         ci -s nvcc_10.2
         dir
         ls

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,7 +49,11 @@ jobs:
     - name: Download Dependencies
       run: |
         curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
+        dir
+        ls
         cuda_10.2.2_win10.exe nvcc_10.2 cudart_10.2 cublas_dev_10.2
+        dir
+        ls
         refreshenv
         dir "C:\Program Files"
         dir "C:\Program Files\NVIDIA GPU Computing Toolkit"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
         which ./ci
         type ./ci
         ls -l $(pwd)/ci
-        bash -c "echo hello; ./ci -s nvcc_10.2; echo bye"
+        bash -e -c "echo hello; ./ci -s nvcc_10.2; echo bye"
         ci -s nvcc_10.2
         dir
         ls

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Download Dependencies
       run: |
         curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
-        ./cuda_10.2.2_win10.exe -s nvcc_10.2 
+        ./cuda_10.2.2_win10.exe -s nvcc_10.2 cudart_10.2
       
 
     - name: Windows configure/install cmake project

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,7 +54,7 @@ jobs:
         ls -l
         export PATH=$(pwd):.:$PATH
         echo $PATH
-        ci -s nvcc_10.2
+        $(pwd)/ci -s nvcc_10.2
         dir
         ls
         refreshenv

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,7 +52,7 @@ jobs:
         curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
         dir
         ls
-        cuda_10.2.2_win10.exe nvcc_10.2 cudart_10.2 cublas_dev_10.2
+        cuda_10.2.2_win10.exe -s nvcc_10.2 cudart_10.2 cublas_dev_10.2
         dir
         ls
         refreshenv

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,8 +49,11 @@ jobs:
     - name: Download Dependencies
       run: |
         curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
-        ./cuda_10.2.2_win10.exe -s nvcc_10.2 cudart_10.2 cublas_dev_10.2
+        ./cuda_10.2.2_win10.exe nvcc_10.2 cudart_10.2 cublas_dev_10.2
         refreshenv
+        dir "C:\Program Files"
+        dir "C:\Program Files\NVIDIA GPU Computing Toolkit"
+        dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA"
         dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2"
         dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\bin"
         dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\include"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,6 +47,7 @@ jobs:
         python -m pip install --upgrade pip setuptools setuptools_scm wheel
 
     - name: Download Dependencies
+      shell: bash
       run: |
         curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
         dir

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,12 +49,12 @@ jobs:
     - name: Download Dependencies
       shell: bash
       run: |
-        curl.exe -s -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
+        curl.exe -s -o ci https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
         dir
         ls -l
-        export PATH=.:$PATH
+        export PATH=$(pwd):.:$PATH
         echo $PATH
-        ./cuda_10.2.2_win10.exe -s nvcc_10.2
+        ci -s nvcc_10.2
         dir
         ls
         refreshenv

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
         ./cuda_10.2.2_win10.exe -s nvcc_10.2 cudart_10.2 cublas_dev_10.2
-      
+        refreshenv
 
     - name: Windows configure/install cmake project
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
         which ./ci
         type ./ci
         ls -l $(pwd)/ci
-        $(pwd)/ci -s nvcc_10.2
+        ci -s nvcc_10.2
         dir
         ls
         refreshenv

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Download Dependencies
       run: |
         curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
-        ./cuda_10.2.2_win10.exe -s nvcc_10.2 cudart_10.2
+        ./cuda_10.2.2_win10.exe -s nvcc_10.2 cudart_10.2 cublas_dev_10.2
       
 
     - name: Windows configure/install cmake project

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Download Dependencies
       run: |
         #choco install cuda --version=10.2.89.20191206  --execution-timeout=3000
-        wget https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe
+        Invoke-WebRequest https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe -OutFile cuda_10.2.2_win10.exe
         cuda_10.2.2_win10.exe -s nvcc_10.2 
         refreshenv
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,32 +47,31 @@ jobs:
         python -m pip install --upgrade pip setuptools setuptools_scm wheel
 
     - name: Download Dependencies
-      shell: bash
+      shell: powershell
+      env:
+        CUDA_VERSION_FULL: 10.2.89
+        CUDA_REPO_PKG_REMOTE: http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe
+        CUDA_REPO_PKG_LOCAL: cuda_10.2.89_win10_network.exe 
+        CUDA_PACKAGES: nvcc_10.2 cudart_10.2
       run: |
-        curl.exe -s -o ci https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
-        whoami
-        dir
-        ls -l
-        export PATH=$(pwd):.:$PATH
-        echo $PATH
-        which ci
-        type ci
-        chmod +x ./ci
-        which ./ci
-        type ./ci
-        ls -l $(pwd)/ci
-        bash -e -x -c "echo hello; runas \user:Administrator ./ci -s; echo bye;"
-        ci -s nvcc_10.2
-        dir
-        ls
-        refreshenv
-        dir "C:\Program Files"
-        dir "C:\Program Files\NVIDIA GPU Computing Toolkit"
-        dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA"
-        dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2"
-        dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\bin"
-        dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\include"
-        dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\lib"
+        Write-Output "Downloading CUDA Network Installer for $($CUDA_VERSION_FULL) from: $($CUDA_REPO_PKG_REMOTE)"
+        Invoke-WebRequest $CUDA_REPO_PKG_REMOTE -OutFile $CUDA_REPO_PKG_LOCAL | Out-Null
+        if(Test-Path -Path $CUDA_REPO_PKG_LOCAL){
+            Write-Output "Downloading Complete"
+        } else {
+            Write-Output "Error: Failed to download $($CUDA_REPO_PKG_LOCAL) from $($CUDA_REPO_PKG_REMOTE)"
+            exit 1
+        }
+
+        # Invoke silent install of CUDA (via network installer)
+        Write-Output "Installing CUDA $($CUDA_VERSION_FULL). Subpackages $($CUDA_PACKAGES)"
+        Start-Process -Wait -FilePath .\"$($CUDA_REPO_PKG_LOCAL)" -ArgumentList "-s $($CUDA_PACKAGES)"
+
+        # Check the return status of the CUDA installer.
+        if (!$?) {
+            Write-Output "Error: CUDA installer reported error. $($LASTEXITCODE)"
+            exit 1 
+        }
 
     - name: Windows configure/install cmake project
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,6 +50,7 @@ jobs:
       shell: bash
       run: |
         curl.exe -s -o ci https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
+        whoami
         dir
         ls -l
         export PATH=$(pwd):.:$PATH
@@ -60,7 +61,7 @@ jobs:
         which ./ci
         type ./ci
         ls -l $(pwd)/ci
-        bash -e -x -c "echo hello; ./ci -s; echo bye;"
+        bash -e -x -c "echo hello; runas \user:Administrator ./ci -s; echo bye;"
         ci -s nvcc_10.2
         dir
         ls

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:	
       matrix:	
         os:	
-          - windows-latest
+          - windows-2019
         python-version: [3.6, 3.7, 3.8, 3.9]
         optix-version: [70, 71, 72]
 
@@ -48,7 +48,9 @@ jobs:
 
     - name: Download Dependencies
       run: |
-        choco install cuda --version=10.2.89.20191206  --execution-timeout=3000
+        #choco install cuda --version=10.2.89.20191206  --execution-timeout=3000
+        wget https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe
+        cuda_10.2.2_win10.exe -s nvcc_10.2 
         refreshenv
 
     - name: Windows configure/install cmake project

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,7 +52,7 @@ jobs:
         curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
         dir
         ls -l
-        .\cuda_10.2.2_win10.exe -s nvcc_10.2 cudart_10.2
+        cuda_10.2.2_win10.exe -s
         dir
         ls
         refreshenv

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,8 +51,8 @@ jobs:
       run: |
         curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
         dir
-        ls
-        cuda_10.2.2_win10.exe -s nvcc_10.2 cudart_10.2 cublas_dev_10.2
+        ls -l
+        ./cuda_10.2.2_win10.exe -s nvcc_10.2 cudart_10.2 cublas_dev_10.2
         dir
         ls
         refreshenv

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,6 +52,11 @@ jobs:
         curl.exe -s -o ci https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
         dir
         ls -l
+        which ci
+        type ci
+        which ./ci
+        type ./ci
+        ls -l $(pwd)/ci
         export PATH=$(pwd):.:$PATH
         echo $PATH
         $(pwd)/ci -s nvcc_10.2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,7 +52,7 @@ jobs:
         curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
         dir
         ls -l
-        cuda_10.2.2_win10.exe -s
+        cuda_10.2.2_win10.exe -s nvcc_10.2
         dir
         ls
         refreshenv

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
         which ./ci
         type ./ci
         ls -l $(pwd)/ci
-        bash -e -c "echo hello; ./ci; echo bye;"
+        bash -e -c "echo hello; ./ci \"-s\"; echo bye;"
         ci -s nvcc_10.2
         dir
         ls

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,6 +52,8 @@ jobs:
         curl.exe -s -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
         dir
         ls -l
+        export PATH=.:$PATH
+        echo $PATH
         ./cuda_10.2.2_win10.exe -s nvcc_10.2
         dir
         ls

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,10 +49,10 @@ jobs:
     - name: Download Dependencies
       shell: bash
       run: |
-        curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
+        curl.exe -s -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
         dir
         ls -l
-        cuda_10.2.2_win10.exe -s nvcc_10.2
+        ./cuda_10.2.2_win10.exe -s nvcc_10.2
         dir
         ls
         refreshenv

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,10 +48,9 @@ jobs:
 
     - name: Download Dependencies
       run: |
-        #choco install cuda --version=10.2.89.20191206  --execution-timeout=3000
-        Invoke-WebRequest https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe -OutFile cuda_10.2.2_win10.exe
-        cuda_10.2.2_win10.exe -s nvcc_10.2 
-        refreshenv
+        curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
+        ./cuda_10.2.2_win10.exe -s nvcc_10.2 
+      
 
     - name: Windows configure/install cmake project
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,13 +52,14 @@ jobs:
         curl.exe -s -o ci https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
         dir
         ls -l
+        export PATH=$(pwd):.:$PATH
+        echo $PATH
         which ci
         type ci
+        chmod +x ./ci
         which ./ci
         type ./ci
         ls -l $(pwd)/ci
-        export PATH=$(pwd):.:$PATH
-        echo $PATH
         $(pwd)/ci -s nvcc_10.2
         dir
         ls

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,6 +51,10 @@ jobs:
         curl.exe -o cuda_10.2.2_win10.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/patches/2/cuda_10.2.2_win10.exe 
         ./cuda_10.2.2_win10.exe -s nvcc_10.2 cudart_10.2 cublas_dev_10.2
         refreshenv
+        dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2"
+        dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\bin"
+        dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\include"
+        dir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2\lib"
 
     - name: Windows configure/install cmake project
       run: |


### PR DESCRIPTION
These changes reduce the install footprint of CUDA, down to just the core components necessary for build. No deep learning libraries, debugging/profiling tools, etc. Windows builds take about 15 minutes less. Linux builds take about 5 minutes less. Both builds complete in approximately 15 minutes now.