### PR TITLE
Fix Windows Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# Unified workflow for building, (TODO, building docs), and conditionally deploying to PyPI for NVISII
+# Unified workflow for building, building docs, and conditionally deploying to PyPI for NVISII
 name: CI
 
 on:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
         env:
           OPTIX_VERSION: ${{ matrix.optix-version }}
         run: |
-          pip install --upgrade pip setuptools setuptools_scm wheel numpy==1.19.5
+          pip install --upgrade setuptools setuptools_scm wheel numpy==1.19.5
           mkdir build
           cd build
           cmake ../ -DCUDA_TOOLKIT_ROOT_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.2" -DPYTHON_VERSION="${{matrix.python-version}}"


### PR DESCRIPTION
The VM-provided version of pip became unmodifiable in the windows image, causing the installation of dependencies to break. This PR removed pip from the requested dependencies (which uses pip itself to install, so pip must be otherwise installed anyways). All builds (and docs updates!) should now succeed. 